### PR TITLE
fix IndexError if tree value is squeezed into a single float

### DIFF
--- a/treeinterpreter/treeinterpreter.py
+++ b/treeinterpreter/treeinterpreter.py
@@ -47,6 +47,9 @@ def _predict_tree(model, X):
 
     # remove the single-dimensional inner arrays
     values = model.tree_.value.squeeze()
+    # reshape if squeezed into a single float
+    if len(values.shape) == 0:
+        values = np.array([values])
 
     if type(model) == DecisionTreeRegressor:
         contributions = np.zeros(X.shape)


### PR DESCRIPTION
For some trees in sklearn, the package raises error:
```
    return _predict_forest(model, X)
  File "python2.7/site-packages/treeinterpreter/treeinterpreter.py", line 96, in _predict_forest
    pred, bias, contribution = _predict_tree(tree, X)
  File "python2.7/site-packages/treeinterpreter/treeinterpreter.py", line 74, in _predict_tree
    biases[row] = values[path[0]]
```

Error happens when tree value is squeezed into float instead of the 1-D array of floats.