### PR TITLE
Gradient boosting implementation

### DIFF
--- a/treeinterpreter/treeinterpreter.py
+++ b/treeinterpreter/treeinterpreter.py
@@ -111,15 +111,10 @@ def _predict_forest(model, X):
     biases        = np.zeros((X.shape[0], n_classes))
     contributions = np.zeros((X.shape[0], X.shape[1], n_classes))
 
-    if(type(model) == RandomForestClassifier):
+    if(type(model) == RandomForestClassifier or
+       type(model) == RandomForestRegressor):
         for tree in model.estimators_:
-            pred, bias, contribution = _predict_tree(tree, X)
-            predictions   = predictions + pred / n_estimators
-            biases        = biases + bias / n_estimators
-            contributions = contributions + contribution / n_estimators
-    if(type(model) == RandomForestRegressor):
-        for tree in model.estimators_:
-            # No need for last dimension (n_classes == 1) here:
+            # No need for last dimension when n_classes == 1:
             contributions = np.squeeze(contributions)
             predictions = np.squeeze(predictions)
             biases = np.squeeze(biases)


### PR DESCRIPTION
This pull request includes implementation of treeinterpretor for scikit's gradient boosting.
Note about the GBT Classifier: a function is applied to convert scores to probas (usually a logistic function), so for the GBT classifier: probabilities = score_to_proba( bias + sum(contributions) ).

It also fixes a problem of speed encountered with large trees: previously the `_predict_tree` function was going through all the nodes in the tree to predict a line. Now it only goes from the root to the leaf where the row lies. 
This implementation really decreases the running time for large trees as complexity is now O(log(n)) instead of O(n) - n being the number of nodes.

What do you think about this code ? Please don't hesitate to send feedback about it, or ask me if anything remains unclear.
