### PR TITLE
improve the efficiency of tree leaf contribution calculation

### DIFF
--- a/treeinterpreter/treeinterpreter.py
+++ b/treeinterpreter/treeinterpreter.py
@@ -91,8 +91,10 @@ def _predict_tree(model, X, joint_contribution=False):
         return direct_prediction, biases, contributions
         
     else:
-
-        for row, leaf in enumerate(leaves):
+        unique_leaves = np.unique(leaves)
+        unique_contributions = {}
+        
+        for row, leaf in enumerate(unique_leaves):
             for path in paths:
                 if leaf == path[-1]:
                     break
@@ -103,8 +105,11 @@ def _predict_tree(model, X, joint_contribution=False):
                 contrib = values_list[path[i+1]] - \
                          values_list[path[i]]
                 contribs[feature_index[path[i]]] += contrib
-            contributions.append(contribs)
-    
+            unique_contributions[leaf] = contribs
+            
+        for row, leaf in enumerate(leaves):
+            contributions.append(unique_contributions[leaf])
+
         return direct_prediction, biases, np.array(contributions)
 
 


### PR DESCRIPTION
The original code calculates the tree-level contribution vector for each instance. Provided each instance would definitely fall down to one of the leaf nodes, this process can be more efficient for the large dataset with some small modification:
1. Calculate the contribution vector for each unique tree leaf nodes and store the result into a dictionary, whose keys are leaf nodes and each key refers to the contribution vector of the leaf node.
2. Assign the contribution vector to each instance regarding which leaf node it is assigned. (Avoid the calculation for each instance)