### PR TITLE
Add support for more sklearn trees

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,12 @@ It works on scikit-learn's
 
 * DecisionTreeRegressor
 * DecisionTreeClassifier
+* ExtraTreeRegressor
+* ExtraTreeClassifier
 * RandomForestRegressor
 * RandomForestClassifier
+* ExtraTreesRegressor
+* ExtraTreesClassifier
 
 Free software: BSD license
 


### PR DESCRIPTION
Specifically, target support for sklearn's `ExtraTreeRegressor`, `ExtraTreeClassifier`, `ExtraTreesRegressor`, and `ExtraTreesClassifier`. This is implemented by removing explicit checks on `type(model) == DecisionTreeRegressor`, etc. and allowing subclasses to fit seamlessly within the treeinterpreter framework by having checks on `isinstance(model, DecisionTreeRegressor)`.

See http://scikit-learn.org/stable/modules/ensemble.html#extremely-randomized-trees for more details on ExtraTrees estimators.

XGBoost and other gradient-boosted estimators do not inherit from the `DecisionTreeRegressor` or `ForestRegressor` classes, and thus support is *not* provided for them through this PR, as seems to have been a concern in previous contributions.