### PR TITLE
Fixed a crash on trees with depth of 0.

### DIFF
--- a/treeinterpreter/treeinterpreter.py
+++ b/treeinterpreter/treeinterpreter.py
@@ -52,7 +52,7 @@ def _predict_tree(model, X, joint_contribution=False):
         leaf_to_path[path[-1]] = path         
     
     # remove the single-dimensional inner arrays
-    values = model.tree_.value.squeeze()
+    values = model.tree_.value.squeeze(axis=1)
     # reshape if squeezed into a single float
     if len(values.shape) == 0:
         values = np.array([values])


### PR DESCRIPTION
A fix for issue #4.

Can be reproduced by running the following:
```python
import numpy as np
from sklearn.ensemble import RandomForestClassifier
from treeinterpreter import treeinterpreter as ti


X = np.array([[0, 0], [1, 1]])
Y = [0, 1]

rf = RandomForestClassifier(n_estimators=10)
rf = rf.fit(X, Y)

prediction, bias, contributions = ti.predict(rf, X)
```
